### PR TITLE
feat: add whole-file crypto service

### DIFF
--- a/src/main/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFile.java
+++ b/src/main/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFile.java
@@ -1,0 +1,102 @@
+package com.lazhoff.mule.secureprops.crypto;
+
+import com.lazhoff.mule.secureprops.adapter.SecurePropertiesConfig;
+import com.lazhoff.mule.secureprops.adapter.SecurePropertiesToolAdapter;
+import com.lazhoff.mule.secureprops.adapter.SecurePropertiesToolRunner;
+import com.lazhoff.mule.secureprops.util.TempFileManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+
+import static com.lazhoff.mule.secureprops.crypto.CryptoExecutionResult.Status.*;
+
+public class DefaultCryptoServiceWholeFile implements ICryptoService {
+
+    private static final Logger logger = LogManager.getLogger(DefaultCryptoServiceWholeFile.class);
+
+    private final CryptoConfig config;
+    private final SecurePropertiesToolRunner runner;
+    private final TempFileManager tempFileManager;
+
+    public DefaultCryptoServiceWholeFile(CryptoConfig config) {
+        this.config = config;
+        this.runner = new SecurePropertiesToolAdapter();
+        this.tempFileManager = new TempFileManager(config.getTempFolder());
+    }
+
+    @Override
+    public CryptoExecutionResult.Status encrypt() {
+        return process(SecurePropertiesConfig.Action.ENCRYPT);
+    }
+
+    @Override
+    public CryptoExecutionResult.Status decrypt() {
+        return process(SecurePropertiesConfig.Action.DECRYPT);
+    }
+
+    private CryptoExecutionResult.Status process(SecurePropertiesConfig.Action action) {
+        Path file = Path.of(config.getFilePath());
+        Path temp = null;
+
+        try {
+            temp = tempFileManager.createTempSecureFile();
+
+            SecurePropertiesConfig secureConfig = new SecurePropertiesConfig(
+                    SecurePropertiesConfig.Type.WHOLE_FILE,
+                    action,
+                    config.getAlgorithm(),
+                    config.getMode(),
+                    config.getKey(),
+                    null,
+                    file.toString(),
+                    temp.toString(),
+                    config.isUseRandomIV()
+            );
+
+            SecurePropertiesToolAdapter.ExecutionResult result = runner.run(secureConfig);
+            if (result.exitCode != 0) {
+                logger.error("{} failed: {}", action, result.error);
+                return FAILED;
+            }
+
+            if (config.isDryRun()) {
+                byte[] original = Files.readAllBytes(file);
+                byte[] processed = Files.readAllBytes(temp);
+                return Arrays.equals(original, processed) ? UNCHANGED : DRYRUN_CHANGED;
+            }
+
+            if (config.isBackup()) {
+                Path backup = file.resolveSibling(file.getFileName() + ".bak");
+                Files.copy(file, backup, StandardCopyOption.REPLACE_EXISTING);
+                logger.info("Backup created at: {}", backup);
+            }
+
+            Files.move(temp, file, StandardCopyOption.REPLACE_EXISTING);
+            logger.info("{} succeeded. File updated: {}", action, file);
+            return SUCCESS;
+
+        } catch (Exception e) {
+            logger.error("Exception during {}: {}", action, e.toString(), e);
+            return FAILED;
+        } finally {
+            deleteTempFile(temp);
+        }
+    }
+
+    private void deleteTempFile(Path temp) {
+        if (temp != null) {
+            try {
+                Files.deleteIfExists(temp);
+                logger.debug("Temporary file deleted: {}", temp);
+            } catch (IOException e) {
+                logger.warn("Could not delete temp file: {}", temp);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `DefaultCryptoServiceWholeFile` that invokes SecurePropertiesTool to encrypt/decrypt entire files

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e0feef4d88333b451d493bdc9547b