### PR TITLE
Enable CLI debug logging and extend tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <jackson.version>2.17.0</jackson.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
+        <log4j.version>2.23.1</log4j.version>
     </properties>
 
     <dependencies>
@@ -35,9 +36,19 @@
 
         <!-- Logging -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>2.0.12</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
 
         <!-- JUnit Jupiter for testing -->
@@ -54,17 +65,6 @@
             <version>1.0</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.23.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.23.1</version>
-        </dependency>
         <dependency>
             <groupId>org.mule</groupId>
             <artifactId>mule-encryption</artifactId>

--- a/src/main/java/com/lazhoff/mule/secureprops/SecurePropertiesCLI.java
+++ b/src/main/java/com/lazhoff/mule/secureprops/SecurePropertiesCLI.java
@@ -8,6 +8,8 @@ import com.lazhoff.mule.secureprops.gui.MainUI;
 import com.lazhoff.mule.secureprops.util.TempFileManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -49,6 +51,9 @@ public class SecurePropertiesCLI {
 
         boolean dryRun = getFlag(args, "--dryRun");
         boolean debug = getFlag(args, "--debug");
+        if (debug) {
+            Configurator.setLevel("com.lazhoff", Level.DEBUG);
+        }
         boolean backup = !getFlag(args, "--noBackup");
         String tempDir = getValue(args, "--tmp=", TempFileManager.getSystemPathDir().toAbsolutePath().toString());
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
         <Root level="info">
             <AppenderRef ref="Console"/>
         </Root>
-        <Logger name="com.lazhoff" level="debug" additivity="false">
+        <Logger name="com.lazhoff" level="info" additivity="false">
             <AppenderRef ref="Console"/>
         </Logger>
     </Loggers>

--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/CryptoExecutorSummarizeDiffTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/CryptoExecutorSummarizeDiffTest.java
@@ -1,0 +1,36 @@
+package com.lazhoff.mule.secureprops.crypto;
+
+import com.lazhoff.mule.secureprops.util.TempFileManager;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CryptoExecutorSummarizeDiffTest {
+
+    @Test
+    void summarizesChangesBetweenStrings() throws Exception {
+        CryptoConfig config = new CryptoConfig(
+                CryptoConfig.FileOrLine.WHOLE_FILE,
+                ".",
+                "AES",
+                "CBC",
+                "key",
+                false,
+                TempFileManager.getSystemPathDir(),
+                true,
+                false,
+                false
+        );
+
+        CryptoExecutor executor = new CryptoExecutor("encrypt", config, ".*:key");
+
+        Method m = CryptoExecutor.class.getDeclaredMethod("summarizeDiff", String.class, String.class);
+        m.setAccessible(true);
+        String diff = (String) m.invoke(executor, "a\nb\nc\n", "a\nB\nc\n");
+
+        assertTrue(diff.contains("- b"));
+        assertTrue(diff.contains("+ B"));
+    }
+}

--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFileCBCTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFileCBCTest.java
@@ -1,0 +1,44 @@
+package com.lazhoff.mule.secureprops.crypto;
+
+import com.lazhoff.mule.secureprops.util.TempFileManager;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class DefaultCryptoServiceWholeFileCBCTest {
+
+    @Test
+    void encryptsAndDecryptsUsingCbcMode() throws Exception {
+        String original = "cbc-test";
+        Path file = Files.createTempFile("cbc-mode-", ".txt");
+        Files.writeString(file, original);
+
+        CryptoConfig config = new CryptoConfig(
+                CryptoConfig.FileOrLine.WHOLE_FILE,
+                file.toString(),
+                "AES",
+                "CBC",
+                "0000y1230000yXYZ",
+                false,
+                TempFileManager.getSystemPathDir(),
+                false,
+                false,
+                false
+        );
+
+        ICryptoService service = new DefaultCryptoServiceWholeFile(config);
+        service.encrypt();
+        String encrypted = Files.readString(file);
+        assertNotEquals(original, encrypted);
+
+        service.decrypt();
+        String decrypted = Files.readString(file);
+        assertEquals(original, decrypted);
+
+        Files.deleteIfExists(file);
+    }
+}


### PR DESCRIPTION
## Summary
- Switch Log4j default logging to INFO and enable DEBUG when `--debug` flag is supplied
- Consolidate Log4j dependencies under a single version and remove extra logging implementations
- Add tests covering diff summarization and CBC mode encryption/decryption

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_6891d60bb0348333aa4d9d18936a0f46