### PR TITLE
Remove debug CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ java -jar mule-secureprops-cli.jar <encrypt|decrypt> <file|file-level> <folderPa
   <algorithm> <mode> <useRandomIV:true|false> \
   --envKeyMapping="(pattern):(key),(pattern2):(key2)" \
   [--dryRun] \
-  [--debug] \
   [--tmp=TempFolder] \
   [--noBackup]
 ```

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -17,7 +17,7 @@
 ## CLI
 - Run with `java -jar mule-secureprops-cli.jar <encrypt|decrypt> <file|file-level> <folderPath> <algorithm> <mode> <useRandomIV>`
 - Map environment patterns to keys via `--envKeyMapping="(pattern):(key)"`
-- Optional flags: `--dryRun`, `--debug`, `--tmp=TempFolder`, `--noBackup`
+- Optional flags: `--dryRun`, `--tmp=TempFolder`, `--noBackup`
 -- Uses `securepropsHome` to locate defaults
 
 ## UI

--- a/src/main/java/com/lazhoff/mule/secureprops/SecurePropertiesCLI.java
+++ b/src/main/java/com/lazhoff/mule/secureprops/SecurePropertiesCLI.java
@@ -8,8 +8,6 @@ import com.lazhoff.mule.secureprops.gui.MainUI;
 import com.lazhoff.mule.secureprops.util.TempFileManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.config.Configurator;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -31,7 +29,7 @@ public class SecurePropertiesCLI {
                   java -jar mule-secureprops-cli.jar <encrypt|decrypt> <file|file-level> <folderPath> <algorithm> <mode> <useRandomIV:true|false> --envKeyMapping=(regex):(key),...
 
                 Optional:
-                   [--dryRun] [--debug] [--noBackup] [--tmp=TempFolder]
+                   [--dryRun] [--noBackup] [--tmp=TempFolder]
                 """);
             System.exit(1);
         }
@@ -50,10 +48,6 @@ public class SecurePropertiesCLI {
         }
 
         boolean dryRun = getFlag(args, "--dryRun");
-        boolean debug = getFlag(args, "--debug");
-        if (debug) {
-            Configurator.setLevel("com.lazhoff", Level.DEBUG);
-        }
         boolean backup = !getFlag(args, "--noBackup");
         String tempDir = getValue(args, "--tmp=", TempFileManager.getSystemPathDir().toAbsolutePath().toString());
 
@@ -77,7 +71,6 @@ public class SecurePropertiesCLI {
                 useRandomIV,
                 Path.of(tempDir),
                 dryRun,
-                debug,
                 backup
         );
 

--- a/src/main/java/com/lazhoff/mule/secureprops/crypto/CryptoConfig.java
+++ b/src/main/java/com/lazhoff/mule/secureprops/crypto/CryptoConfig.java
@@ -38,7 +38,6 @@ public class CryptoConfig {
     private final Path tempFolder;
 
     private final boolean dryRun;
-    private final boolean debug;
     private final boolean backup;
 
     private final FileOrLine fileOrLine;
@@ -52,7 +51,6 @@ public class CryptoConfig {
             boolean useRandomIV,
             Path tempFolder,
             boolean dryRun,
-            boolean debug,
             boolean backup
     ) {
         this.filePath = filePath;
@@ -62,7 +60,6 @@ public class CryptoConfig {
         this.useRandomIV = useRandomIV;
         this.tempFolder = tempFolder;
         this.dryRun = dryRun;
-        this.debug = debug;
         this.backup = backup;
         this.fileOrLine = fileOrLine;
     }
@@ -93,10 +90,6 @@ public class CryptoConfig {
 
     public boolean isDryRun() {
         return dryRun;
-    }
-
-    public boolean isDebug() {
-        return debug;
     }
 
     public boolean isBackup() {

--- a/src/main/java/com/lazhoff/mule/secureprops/crypto/CryptoExecutor.java
+++ b/src/main/java/com/lazhoff/mule/secureprops/crypto/CryptoExecutor.java
@@ -65,7 +65,6 @@ public class CryptoExecutor {
                         baseConfig.isUseRandomIV(),
                         baseConfig.getTempFolder(),
                         baseConfig.isDryRun(),
-                        baseConfig.isDebug(),
                         baseConfig.isBackup()
                 );
 

--- a/src/main/java/com/lazhoff/mule/secureprops/gui/MainUI.java
+++ b/src/main/java/com/lazhoff/mule/secureprops/gui/MainUI.java
@@ -278,7 +278,6 @@ public class MainUI {
                         argsList.add(Boolean.toString(settings.useRandomIV));
                         argsList.add("--envKeyMapping=" + (fileOrLine=="file-level" ? settings.envKeyMappingPostman: settings.envKeyMappingProperties));
                         if (settings.dryRun)  argsList.add("--dryRun");
-                        if (settings.debug)   argsList.add("--debug");
                         if (!settings.backup) argsList.add("--noBackup");
                         argsList.add("--tmp=" + settings.lastFolder);
 

--- a/src/main/java/com/lazhoff/mule/secureprops/gui/UISettings.java
+++ b/src/main/java/com/lazhoff/mule/secureprops/gui/UISettings.java
@@ -9,7 +9,6 @@ public class UISettings {
     public String lastFolder = "";
     public boolean backup = true;
     public boolean dryRun = false;
-    public boolean debug = false;
 
     public String envKeyMappingPostman = "(local.postman_environment.json):(0000123400001234),((dev|uat|test|mock).postman_environment.json):(0000123400001DEV),(.*.postman_collection.json):(000012340000DEV),(prod.postman_environment.json):(000012340000PROD)";
     public String envKeyMappingProperties = "(secure-config-local.yaml):(0000123400001234),(secure-config-(dev|uat).yaml):(0000123400001DEV),(secure-config-prod.yaml):(000012340000PROD)";
@@ -25,7 +24,6 @@ public class UISettings {
           "lastFolder": "%s",
           "backup": %s,
           "dryRun": %s,
-          "debug": %s,
           "envKeyMappingPostman": "%s",
           "envKeyMappingProperties": "%s",
           "algorithm": "%s",
@@ -33,7 +31,7 @@ public class UISettings {
           "useRandomIV": %s
         }
         """,
-                lastFolder, backup, dryRun, debug,
+                lastFolder, backup, dryRun,
                 envKeyMappingPostman, envKeyMappingProperties,
                 algorithm, mode, useRandomIV);
     }
@@ -42,7 +40,6 @@ public class UISettings {
         this.envKeyMappingPostman = other.envKeyMappingPostman;
         this.envKeyMappingProperties = other.envKeyMappingProperties;
         this.dryRun = other.dryRun;
-        this.debug = other.debug;
         this.backup = other.backup;
         this.algorithm = other.algorithm;
         this.mode = other.mode;

--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/CryptoExecutorSummarizeDiffTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/CryptoExecutorSummarizeDiffTest.java
@@ -20,7 +20,6 @@ class CryptoExecutorSummarizeDiffTest {
                 false,
                 TempFileManager.getSystemPathDir(),
                 true,
-                false,
                 false
         );
 

--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFileCBCTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFileCBCTest.java
@@ -26,7 +26,6 @@ class DefaultCryptoServiceWholeFileCBCTest {
                 false,
                 TempFileManager.getSystemPathDir(),
                 false,
-                false,
                 false
         );
 

--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFileDecryptTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFileDecryptTest.java
@@ -29,7 +29,6 @@ class DefaultCryptoServiceWholeFileDecryptTest {
                 false,
                 TempFileManager.getSystemPathDir(),
                 false,
-                false,
                 false
         );
 

--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFileEncryptTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceWholeFileEncryptTest.java
@@ -29,7 +29,6 @@ class DefaultCryptoServiceWholeFileEncryptTest {
                 false,
                 TempFileManager.getSystemPathDir(),
                 false,
-                false,
                 true
         );
 

--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceYamlEncryptTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/DefaultCryptoServiceYamlEncryptTest.java
@@ -34,7 +34,6 @@ class DefaultCryptoServiceYamlEncryptTest {
                 false,  // useRandomIV
                 TempFileManager.getSystemPathDir(),
                 false,  // dryRun
-                false,  // debug
                 true    // backup (ignored)
         );
 


### PR DESCRIPTION
## Summary
- drop `--debug` option from the command-line interface
- remove debug field from runtime config and GUI wiring
- tidy docs and tests for removed flag

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_6892770b761c8333b7c9df7b5b1b85e5