### PR TITLE
Add parameterized AES encryption/decryption test

### DIFF
--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/AESCipherModeTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/AESCipherModeTest.java
@@ -1,0 +1,59 @@
+package com.lazhoff.mule.secureprops.crypto;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AESCipherModeTest {
+
+    private static Stream<Arguments> modeProvider() {
+        return Stream.of(
+                Arguments.of("CBC", "PKCS5Padding", 16),
+                Arguments.of("GCM", "NoPadding", 12),
+                Arguments.of("CFB", "NoPadding", 16)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("modeProvider")
+    void encryptsAndDecrypts(String mode, String padding, int ivLength) throws Exception {
+        String algorithm = "AES";
+        String transformation = algorithm + "/" + mode + "/" + padding;
+        KeyGenerator keyGen = KeyGenerator.getInstance(algorithm);
+        keyGen.init(128);
+        SecretKey key = keyGen.generateKey();
+
+        byte[] iv = new byte[ivLength];
+        new SecureRandom().nextBytes(iv);
+
+        Cipher encryptCipher = Cipher.getInstance(transformation);
+        AlgorithmParameterSpec encSpec = createSpec(mode, iv);
+        encryptCipher.init(Cipher.ENCRYPT_MODE, key, encSpec);
+
+        String input = "sample-text";
+        byte[] encrypted = encryptCipher.doFinal(input.getBytes(StandardCharsets.UTF_8));
+
+        Cipher decryptCipher = Cipher.getInstance(transformation);
+        AlgorithmParameterSpec decSpec = createSpec(mode, iv);
+        decryptCipher.init(Cipher.DECRYPT_MODE, key, decSpec);
+        byte[] decrypted = decryptCipher.doFinal(encrypted);
+
+        assertEquals(input, new String(decrypted, StandardCharsets.UTF_8));
+    }
+
+    private static AlgorithmParameterSpec createSpec(String mode, byte[] iv) {
+        return "GCM".equals(mode) ? new GCMParameterSpec(128, iv) : new IvParameterSpec(iv);
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit 5 parameterized test covering AES CBC, GCM, and CFB modes with random IVs

## Testing
- `mvn -q test` *(fails: Could not transfer maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68927c6a22148333a0e6a71a09bf1bd4