### PR TITLE
Add algorithm and mode coverage tests

### DIFF
--- a/src/test/java/com/lazhoff/mule/secureprops/crypto/CipherAlgorithmTest.java
+++ b/src/test/java/com/lazhoff/mule/secureprops/crypto/CipherAlgorithmTest.java
@@ -1,0 +1,46 @@
+package com.lazhoff.mule.secureprops.crypto;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class CipherAlgorithmTest {
+
+    private static Stream<Arguments> algorithmProvider() {
+        return Stream.of(
+                Arguments.of("AES", "AES/ECB/PKCS5Padding", 128),
+                Arguments.of("Blowfish", "Blowfish", 128),
+                Arguments.of("DES", "DES/ECB/PKCS5Padding", 56),
+                Arguments.of("DESede", "DESede/ECB/PKCS5Padding", 168),
+                Arguments.of("RC2", "RC2", 128),
+                Arguments.of("RC4", "RC4", 128)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("algorithmProvider")
+    void encryptsAndDecrypts(String algorithm, String transformation, int keySize) throws Exception {
+        KeyGenerator keyGen = KeyGenerator.getInstance(algorithm);
+        keyGen.init(keySize);
+        SecretKey key = keyGen.generateKey();
+        Cipher cipher = Cipher.getInstance(transformation);
+
+        byte[] input = "sample-text".getBytes(StandardCharsets.UTF_8);
+
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+        byte[] encrypted = cipher.doFinal(input);
+
+        cipher.init(Cipher.DECRYPT_MODE, key);
+        byte[] decrypted = cipher.doFinal(encrypted);
+
+        assertArrayEquals(input, decrypted);
+    }
+}


### PR DESCRIPTION
## Summary
- expand AES cipher mode parameter tests to cover CBC, CFB, ECB and OFB
- add parameterized encryption/decryption test across AES, Blowfish, DES, DESede, RC2 and RC4 algorithms

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892eae68d4c8333bda1a74315a7103a